### PR TITLE
chore(release): prep package.xml and changelog for the first rosdistro release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,14 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ndt_omp_ros2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.1.0 (2026-06-11)
+------------------
+* First release prepared for the ROS 2 buildfarm (Humble / Jazzy).
+* ROS 2 port of koide3/ndt_omp (OpenMP boosted NDT / GICP, BSD-2-Clause)
+  with Humble support, an NDT Hessian fix, and a rotation/translation
+  prior + mean-correspondence-distance API used by lidarslam_ros2.
+* Runtime dependencies declared via <depend> so the binary package pulls
+  rclcpp / PCL at install time; SPDX license tag; maintainer updated for
+  the fork (original author credited).
+* Contributors: Ryohei Sasaki, koide

--- a/package.xml
+++ b/package.xml
@@ -1,17 +1,21 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ndt_omp_ros2</name>
-  <version>0.0.0</version>
-  <description>OpenMP boosted NDT and GICP algorithms</description>
+  <version>0.1.0</version>
+  <description>OpenMP boosted NDT and GICP algorithms (ROS 2 port)</description>
 
-  <maintainer email="koide@aisl.cs.tut.ac.jp">koide</maintainer>
+  <maintainer email="rsasaki0109@gmail.com">Ryohei Sasaki</maintainer>
+  <author email="koide@aisl.cs.tut.ac.jp">koide</author>
 
-  <license>BSD</license>
+  <license>BSD-2-Clause</license>
+
+  <url type="repository">https://github.com/rsasaki0109/ndt_omp_ros2</url>
+  <url type="bugtracker">https://github.com/rsasaki0109/ndt_omp_ros2/issues</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <build_depend>rclcpp</build_depend>
-  <build_depend>libpcl-all-dev</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <depend>rclcpp</depend>
+  <depend>libpcl-all-dev</depend>
+  <depend>std_msgs</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
## Summary
Repository-side prep so this fork can be bloom-released into Humble/Jazzy — it is the only unreleased dependency of the lidarslam_ros2 core packages (`scanmatcher` / `graph_based_slam` declare `<depend>ndt_omp_ros2</depend>`), so it has to reach rosdistro first. Full ordering and runbook: `docs/rosdistro-release.md` in lidarslam_ros2 (PR rsasaki0109/lidar_slam_ros2#234).

- version 0.0.0 → 0.1.0
- maintainer updated for this fork (original author koide credited via `<author>`)
- SPDX license string `BSD-2-Clause` (matches the LICENSE file)
- `build_depend` → `depend` so the binary deb declares its runtime dependencies (rclcpp / PCL)
- repository / bugtracker `<url>` tags (rosdistro review expects them)
- `CHANGELOG.rst` (REP-132) for the deb changelog

## Test plan
- `catkin_pkg.parse_package` + `catkin_pkg.changelog` both parse cleanly (0.1.0, BSD-2-Clause).
- No code changes; the package builds unchanged in lidarslam_ros2 CI (Humble + Jazzy matrix) as a submodule.